### PR TITLE
feat: allow jwt disclosure result to be sent back with disclosure sessions

### DIFF
--- a/config/default-config.js
+++ b/config/default-config.js
@@ -30,6 +30,7 @@ const defaults = {
     host: '127.0.0.1',
     port: '6379',
   },
+  addDisclosureJwt: false,
 };
 
 module.exports = defaults;

--- a/diva-irma.js
+++ b/diva-irma.js
@@ -191,7 +191,16 @@ function completeDisclosureSession(irmaSessionId, token) {
   return verifyIrmaApiServerJwt(token, divaConfig.jwtIrmaApiServerVerifyOptions)
     .then((disclosureProofResult) => {
       divaState.setIrmaEntry(irmaSessionId, 'COMPLETED'); // Async
-      return { disclosureProofResult, proofStatus: disclosureProofResult.status };
+      const result = { disclosureProofResult, proofStatus: disclosureProofResult.status };
+
+      if (divaConfig.addDisclosureJwt) {
+        return {
+          ...result,
+          jwt: token,
+        };
+      }
+
+      return result;
     });
 }
 


### PR DESCRIPTION
With this PR, we can send a JWT back to the frontend. This is useful in some cases, for instance when the frontend will redirect to another page with the JWT disclosure result as query parameter.

By default, this feature is turned off, so it won't break any previous applications using this library.

Using this feature in the reference-3p backend is very simple, see this commit: https://github.com/Alliander/diva-js-reference-3p-backend/commit/bfa3647537caa10cfac5e3393f25743052b35903